### PR TITLE
Adds drush-backups mount to .platform.app.yaml

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -89,6 +89,7 @@ mounts:
     '/web/sites/default/files': 'shared:files/files'
     '/tmp': 'shared:files/tmp'
     '/private': 'shared:files/private'
+    '/drush-backups': 'shared:files/drush-backups'
 
 # The hooks executed at various points in the lifecycle of the application.
 hooks:


### PR DESCRIPTION
The docs file .platform.app.yaml should contain a mount point for drush backups to ensure that drush sql-sync command can successfully write to the drush-backups directory and complete.