### PR TITLE
Use drush and drupal from the project's compser.lock

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -13,12 +13,6 @@ type: 'php:7.0'
 build:
     flavor: composer
 
-# The build-time dependencies of the app.
-dependencies:
-    php:
-        'drush/drush': '^8.0'
-        'drupal/console': '@stable'
-
 # The relationships of the application with services or other applications.
 #
 # The left-hand side is the name of the relationship as it will be exposed
@@ -93,6 +87,13 @@ mounts:
 
 # The hooks executed at various points in the lifecycle of the application.
 hooks:
+    build: |
+      mkdir -p .global/bin
+      (
+        set -e
+        cd .global/bin
+        ln -s ../../vendor/bin/* .
+      )
     # We run deploy hook after your application has been deployed and started.
     deploy: |
       cd web


### PR DESCRIPTION
Not sure if this is the best way, but 

``` yaml
# The build-time dependencies of the app.
dependencies:
    php:
        'drush/drush': '^8.0'
        'drupal/console': '@stable'
```

Install only stable releases globally, while this is OK for drush, drupal-console is very old.

But regardless of that, and knowing that you can overcome this somehow, these tools are also installed project-wise by drupal-composer or this [project's own composer.json](../blob/master/composer.json#L23-L24) so I wonder if it's simply not better to use that instead of installing globally, and only allow them to be properly accessed.

On a side not, I think `~/vendor/bin` should be in the shell path anyway.

Maybe there's a way to set it to the path instead of doing the symlink?
