### PR TITLE
Set the Drupal deployment_identifier

### DIFF
--- a/scripts/platformsh/dist.settings.platformsh.php
+++ b/scripts/platformsh/dist.settings.platformsh.php
@@ -105,3 +105,8 @@ if (isset($_ENV['PLATFORM_VARIABLES'])) {
 if (isset($_ENV['PLATFORM_PROJECT_ENTROPY']) && empty($settings['hash_salt'])) {
   $settings['hash_salt'] = $_ENV['PLATFORM_PROJECT_ENTROPY'];
 }
+
+// Sete the deployment identifier, which is used by some Drupal cache systems.
+if (isset($_ENV['PLATFORM_TREE_ID']) && empty($settings['deployment_identifier'])) {
+  $settings['deployment_identifier'] = $_ENV['PLATFORM_TREE_ID'];
+}

--- a/web/sites/default/settings.platformsh.php
+++ b/web/sites/default/settings.platformsh.php
@@ -105,3 +105,8 @@ if (isset($_ENV['PLATFORM_VARIABLES'])) {
 if (isset($_ENV['PLATFORM_PROJECT_ENTROPY']) && empty($settings['hash_salt'])) {
   $settings['hash_salt'] = $_ENV['PLATFORM_PROJECT_ENTROPY'];
 }
+
+// Sete the deployment identifier, which is used by some Drupal cache systems.
+if (isset($_ENV['PLATFORM_TREE_ID']) && empty($settings['deployment_identifier'])) {
+  $settings['deployment_identifier'] = $_ENV['PLATFORM_TREE_ID'];
+}


### PR DESCRIPTION
I only just learned about this thing, which may end up being extremely useful for managing the Twig cache in a multi-head environment.  (I think it's a recent addition.)  It also seems like something we should just set generally to help with cache invalidation.  So let's do that.