### PR TITLE
Revert "Use Composer's bin dir instead of vendor/bin"

### DIFF
--- a/.environment
+++ b/.environment
@@ -3,9 +3,6 @@
 # environment.
 
 # Allow executable app dependencies from Composer to be run from the path.
-if [ -n "$PLATFORM_APP_DIR" -a -f "$PLATFORM_APP_DIR"/composer.json ] ; then
-  bin=$(composer config bin-dir --working-dir="$PLATFORM_APP_DIR" --no-interaction 2>/dev/null)
-  if [ -n "$bin" ] ; then
-    export PATH="${PLATFORM_APP_DIR}/${bin}:${PATH}"
-  fi
+if [ -n "$PLATFORM_APP_DIR" ] ; then
+  export PATH="${PLATFORM_APP_DIR}/vendor/bin:$PATH"
 fi


### PR DESCRIPTION
This reverts commit 98cb64d3b8872d3a751f3f2eb2ea0ee053cc96fe.

Fix the composer folder in PE.