### PR TITLE
Use 'vendor/bin' if a bin-dir is not found

### DIFF
--- a/.environment
+++ b/.environment
@@ -5,7 +5,5 @@
 # Allow executable app dependencies from Composer to be run from the path.
 if [ -n "$PLATFORM_APP_DIR" -a -f "$PLATFORM_APP_DIR"/composer.json ] ; then
   bin=$(composer config bin-dir --working-dir="$PLATFORM_APP_DIR" --no-interaction 2>/dev/null)
-  if [ -n "$bin" ] ; then
-    export PATH="${PLATFORM_APP_DIR}/${bin}:${PATH}"
-  fi
+  export PATH="${PLATFORM_APP_DIR}/${bin:-vendor/bin}:${PATH}"
 fi


### PR DESCRIPTION
Following on from discussion in #44 

I've tried out the ternary operator and quoting in Dash and Bash.