### PR TITLE
Revise variable handling to handle deeply nested config variables.

### DIFF
--- a/scripts/platformsh/dist.settings.platformsh.php
+++ b/scripts/platformsh/dist.settings.platformsh.php
@@ -78,27 +78,40 @@ if (getenv('PLATFORM_ROUTES') && !isset($settings['trusted_host_patterns'])) {
 if (getenv('PLATFORM_VARIABLES')) {
   $variables = json_decode(base64_decode(getenv('PLATFORM_VARIABLES')), TRUE);
   foreach ($variables as $name => $value) {
-    // A variable named "d8settings:example-setting" will be saved in
-    // $settings['example-setting'].
-    if (strpos($name, 'd8settings:') === 0) {
-      $settings[substr($name, 11)] = $value;
-    }
-    // A variable named "drupal:example-setting" will be saved in
-    // $settings['example-setting'] (backwards compatibility).
-    elseif (strpos($name, 'drupal:') === 0) {
-      $settings[substr($name, 7)] = $value;
-    }
-    // A variable named "d8config:example-name:example-key" will be saved in
-    // $config['example-name']['example-key'].
-    elseif (strpos($name, 'd8config:') === 0 && substr_count($name, ':') >= 2) {
-      list(, $config_key, $config_name) = explode(':', $name, 3);
-      $config[$config_key][$config_name] = $value;
-    }
-    // A complex variable named "d8config:example-name" will be saved in
-    // $config['example-name'].
-    elseif (strpos($name, 'd8config:') === 0 && is_array($value)) {
-      $config[substr($name, 9)] = $value;
-    }
+    $parts = explode(':', $name);
+    list($prefix, $key) = array_pad($parts, 3, null);
+    switch ($prefix) {
+      // Variables that begin with `d8settings` or `drupal` get mapped
+      // to the $settings array verbatim, even if the value is an array.
+      // For example, a variable named d8settings:example-setting' with
+      // value 'foo' becomes $settings['example-setting'] = 'foo';
+      case 'd8settings':
+      case 'drupal':
+          $settings[$key] = $value;
+          break;
+      // Variables that begin with `d8config` get mapped to the $config
+      // array.  Deeply nested variable names, with colon delimiters,
+      // get mapped to deeply nested array elements. Array values
+      // get added to the end just like a scalar. Variables without
+      // both a config object name and property are skipped.
+      // Example: Variable `d8config:conf_file:prop` with value `foo` becomes
+      // $config['conf_file']['prop'] = 'foo';
+      // Example: Variable `d8config:conf_file:prop:subprop` with value `foo` becomes
+      // $config['conf_file']['prop']['subprop'] = 'foo';
+      // Example: Variable `d8config:conf_file:prop:subprop` with value ['foo' => 'bar'] becomes
+      // $config['conf_file']['prop']['subprop']['foo'] = 'bar';
+      // Example: Variable `d8config:prop` is ignored.
+      case 'd8config':
+        if (count($parts) > 2) {
+          $temp = &$config[$key];
+          foreach (array_slice($parts, 2) as $n) {
+            $prev = &$temp;
+            $temp = &$temp[$n];
+          }
+          $prev[$n] = $value;
+        }
+        break;
+      }
   }
 }
 

--- a/web/sites/default/settings.platformsh.php
+++ b/web/sites/default/settings.platformsh.php
@@ -78,26 +78,39 @@ if (getenv('PLATFORM_ROUTES') && !isset($settings['trusted_host_patterns'])) {
 if (getenv('PLATFORM_VARIABLES')) {
   $variables = json_decode(base64_decode(getenv('PLATFORM_VARIABLES')), TRUE);
   foreach ($variables as $name => $value) {
-    // A variable named "d8settings:example-setting" will be saved in
-    // $settings['example-setting'].
-    if (strpos($name, 'd8settings:') === 0) {
-      $settings[substr($name, 11)] = $value;
-    }
-    // A variable named "drupal:example-setting" will be saved in
-    // $settings['example-setting'] (backwards compatibility).
-    elseif (strpos($name, 'drupal:') === 0) {
-      $settings[substr($name, 7)] = $value;
-    }
-    // A variable named "d8config:example-name:example-key" will be saved in
-    // $config['example-name']['example-key'].
-    elseif (strpos($name, 'd8config:') === 0 && substr_count($name, ':') >= 2) {
-      list(, $config_key, $config_name) = explode(':', $name, 3);
-      $config[$config_key][$config_name] = $value;
-    }
-    // A complex variable named "d8config:example-name" will be saved in
-    // $config['example-name'].
-    elseif (strpos($name, 'd8config:') === 0 && is_array($value)) {
-      $config[substr($name, 9)] = $value;
+    $parts = explode(':', $name);
+    list($prefix, $key) = array_pad($parts, 3, null);
+    switch ($prefix) {
+      // Variables that begin with `d8settings` or `drupal` get mapped
+      // to the $settings array verbatim, even if the value is an array.
+      // For example, a variable named d8settings:example-setting' with
+      // value 'foo' becomes $settings['example-setting'] = 'foo';
+      case 'd8settings':
+      case 'drupal':
+        $settings[$key] = $value;
+        break;
+      // Variables that begin with `d8config` get mapped to the $config
+      // array.  Deeply nested variable names, with colon delimiters,
+      // get mapped to deeply nested array elements. Array values
+      // get added to the end just like a scalar. Variables without
+      // both a config object name and property are skipped.
+      // Example: Variable `d8config:conf_file:prop` with value `foo` becomes
+      // $config['conf_file']['prop'] = 'foo';
+      // Example: Variable `d8config:conf_file:prop:subprop` with value `foo` becomes
+      // $config['conf_file']['prop']['subprop'] = 'foo';
+      // Example: Variable `d8config:conf_file:prop:subprop` with value ['foo' => 'bar'] becomes
+      // $config['conf_file']['prop']['subprop']['foo'] = 'bar';
+      // Example: Variable `d8config:prop` is ignored.
+      case 'd8config':
+        if (count($parts) > 2) {
+          $temp = &$config[$key];
+          foreach (array_slice($parts, 2) as $n) {
+            $prev = &$temp;
+            $temp = &$temp[$n];
+          }
+          $prev[$n] = $value;
+        }
+        break;
     }
   }
 }


### PR DESCRIPTION
The current code forces you to use a JSON array for anything but a top level property, which is unpleasant and confusing.  This new code lets you deeply nest the property name with colons.  See inline examples.

I've tested the code itself extensively in isolation, but not in a Drupal site yet.

Once this is accepted I'll also port it over to the new template builder.